### PR TITLE
use unsafe load to work with newer versions of ruby

### DIFF
--- a/Fan_Control.rb
+++ b/Fan_Control.rb
@@ -20,7 +20,7 @@ module R710_Tools
       @@config_locations.each do |loc|
         if File.exist?(loc)
           puts "Loading configuration from #{loc}".colorize(:yellow)
-          @config = YAML.load_file(loc)
+          @config = YAML.unsafe_load_file(loc)
           break
         end
       end


### PR DESCRIPTION
Ranges are restricted by default otherwise